### PR TITLE
Support multiple comment delimiters

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,30 @@ module.exports = {
     }
 };
 ```
+If you need to use multiple comment tags in one file to mark the start and end of the block to strip from your code, you can add options for "start" and "end" like this:
+
+```javascript
+var blocks = ['develblock'];
+module.exports = {
+  rules: [
+    {
+      test: /\.html$/,
+      enforce: 'pre',
+      use: [
+        {
+          loader: 'webpack-strip-block',
+          options: {
+            blocks: blocks,
+            start: ['/*', '<!--'],
+            end: ['*/', '-->']
+          }
+        }
+      ]
+    }
+  ]
+};
+```
+Make sure to use the same comment tag order in both "start" and "end".
 
 ## Laravel Mix sample
 

--- a/index.js
+++ b/index.js
@@ -10,12 +10,17 @@ function regexEscape(str) {
 function StripBlockLoader(content) {
     var options = loaderUtils.getOptions(this);
     if (options && options.blocks) {
-        var start = regexEscape(options.start || '/*');
-        var end = regexEscape(options.end || '/*');
-        options.blocks.forEach(function (block) {
-            var regex = new RegExp('[\\t ]*' + start + ' ?(' + block + '):start ?' + end + '[\\s\\S]*?' + start + ' ?\\1:end ?' + end + '[\\t ]*\\n?', 'g');
-            content = content.replace(regex, '');
-        });
+        var start = Array.isArray(options.start) ? options.start : [options.start || '/*'];
+        var end = Array.isArray(options.end) ? options.end : [options.end || '/*'];
+        for(var i = 0; i < start.length; i++)
+        {
+            var starti = regexEscape(start[i] || '/*');
+            var endi = regexEscape(end[i] || '/*');
+            options.blocks.forEach(function (block) {
+                var regex = new RegExp('[\\t ]*' + starti + ' ?(' + block + '):start ?' + endi + '[\\s\\S]*?' + starti + ' ?\\1:end ?' + endi + '[\\t ]*\\n?', 'g');
+                content = content.replace(regex, '');
+            });
+        }
     }
 
     if (this.cacheable) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "webpack-strip-blocks",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Webpack plugin to strip blocks of code that's only intended for development purposes",
     "main": "index.js",
     "repository": {
@@ -22,6 +22,9 @@
         "name": "Alexander Wunschik",
         "email": "mail@wunschik.it",
         "url": "http://www.wunschik.it"
+    }, {
+        "name": "Christian Sander",
+        "email": "christian.sander85@gmail.com",
     }],
     "license": "MIT",
     "peerDependencies": {


### PR DESCRIPTION
I needed to be able to use multiple comment delimiters in one file for a project using Svelte, so I added the possibility to specify multiple comment delimiters in an array. It is still possible to use a single delimiter.